### PR TITLE
Make prerequisites more clear and add Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,21 @@ Users could choose to install Anaconda, if they want. If using Anaconda or Entho
     $ virtualenv env
     $ source env/bin/activate
 
-####Install reqirements from requirements file
-    $ pip install -r requirements.txt
-
-####Note: Make sure you have libraries for png & freetype.
-Ubuntu users can install the below
+####Install Prerequisites
+##### Ubuntu
 
     apt-get install libfreetype6-dev
     apt-get install libpng-dev
+
+##### Fedora
+    dnf install libpng-devel.x86_64
+    dnf install freetype-devel.x86_64
+    dnf install lapack-devel
+   
+####Install reqirements from requirements file
+    $ pip install -r requirements.txt
+
+
 
 ###Script to check if installation is fine for the workshop
 Please execute the following at the command prompt


### PR DESCRIPTION
I don't know for a fact that these are required, but these are what I needed to install in order to get check_env.py to pass on Fedora. Feel free not to accept the pull request, I just thought I'd share what worked for me.
